### PR TITLE
DB: connect and execute the schema

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/app.py
+++ b/src/app.py
@@ -2,6 +2,7 @@ from flask import Flask, jsonify, request
 import db
 
 app = Flask(__name__)
+db.connect("./data/db.sqlite3")
 
 @app.route('/files', methods=['GET'])
 def files():

--- a/src/db.py
+++ b/src/db.py
@@ -1,4 +1,7 @@
 from dataclasses import dataclass
+import os
+import sqlite3
+
 
 @dataclass
 class File:
@@ -37,3 +40,20 @@ def add_files(files: list[File]):
     """
     # TODO: add to db
     pass
+
+
+_conn: sqlite3.Connection
+_cur: sqlite3.Cursor
+
+
+def connect(db_path: str):
+    global _conn, _cur
+
+    self_path = os.path.dirname(os.path.realpath(__file__))
+    schema = os.path.join(self_path, "schema.sql")
+
+    _conn = sqlite3.connect(db_path)
+    _cur = _conn.cursor()
+    with open(schema, "r") as f:
+        _cur.executescript(f.read())
+        _conn.commit()

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -1,15 +1,15 @@
-create table files(
+create table if not exists files(
   fid         int auto_increment primary key,
   name        text not null,
   drive_url   text not null
 );
 
-create table tags(
+create table if not exists tags(
   tid         int primary key,
   name        text not null
 );
 
-create table file_tags(
+create table if not exists file_tags(
   tid         int,
   fid         int,
   primary key (tid, fid)


### PR DESCRIPTION
- consumers of db.py must call `db.connect` to intialize the db module
- move schema to src/ for easy discovery by db.py
- `create table` with `if not exists` so we can execute the schema multiple times